### PR TITLE
Feat/visitor counter: Supabase 방문자 카운터 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,15 @@ jiheon-portfolio/
 - GitHub 링크
 - 간단한 소개 문구
 
+### 방문자 카운터 (Supabase)
+
+- DB: Supabase `daily_views` 테이블 (date, count)
+- API: `app/api/views/route.ts` Route Handler에서만 DB 접근
+- total은 별도 컬럼 없이 `sum(count)` 쿼리로 계산 (동기화 문제 방지)
+- 최근 5일 데이터는 `order by date desc limit 5` 쿼리로 조회
+- 환경변수: `SUPABASE_URL`, `SUPABASE_ANON_KEY` (.env.local)
+- RLS 적용으로 클라이언트 직접 접근 차단
+
 ---
 
 ## 컴포넌트 작성 규칙

--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+
+import { supabase } from "@/lib/supabase";
+
+function getToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function GET() {
+  const today = getToday();
+  console.log("[views GET] today:", today);
+
+  const [
+    { data: allData, error: allError },
+    { data: todayData, error: todayError },
+    { data: chartData, error: chartError },
+  ] = await Promise.all([
+    supabase.from("daily_views").select("id, count"),
+    supabase
+      .from("daily_views")
+      .select("id, count")
+      .eq("date", today)
+      .maybeSingle(),
+    supabase
+      .from("daily_views")
+      .select("date, count")
+      .order("date", { ascending: false })
+      .limit(5),
+  ]);
+
+  console.log("[views GET] allData:", allData, allError?.message);
+  console.log("[views GET] todayData:", todayData, todayError?.message);
+  console.log("[views GET] chartData:", chartData, chartError?.message);
+
+  if (allError) console.error("[views GET] allData:", allError.message);
+  if (todayError) console.error("[views GET] todayData:", todayError.message);
+  if (chartError) console.error("[views GET] chartData:", chartError.message);
+
+  const total = allData?.reduce((sum, row) => sum + row.count, 0) ?? 0;
+  const todayCount = todayData?.count ?? 0;
+
+  console.log("[views GET] result → today:", todayCount, "total:", total);
+
+  return NextResponse.json({
+    today: todayCount,
+    total,
+    chart: (chartData ?? []).reverse(),
+  });
+}
+
+export async function POST() {
+  const today = getToday();
+
+  await supabase.rpc("increment_daily_view", { p_date: today });
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,9 +1,14 @@
+import ViewCounter from "@/components/ui/ViewCounter";
+
 export default function Footer() {
   return (
     <footer className="border-t border-(--border) py-8">
-      <p className="text-center text-sm text-(--text-sub) font-body">
-        © 2026 김지헌. All rights reserved.
-      </p>
+      <div className="flex flex-col items-center gap-6">
+        <ViewCounter />
+        <p className="text-center text-sm text-(--text-sub) font-body">
+          © 2026 김지헌. All rights reserved.
+        </p>
+      </div>
     </footer>
   );
 }

--- a/components/ui/ViewCounter.tsx
+++ b/components/ui/ViewCounter.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer } from "recharts";
+
+interface ViewsData {
+  today: number;
+  total: number;
+  chart: { date: string; count: number }[];
+}
+
+interface ChartEntry {
+  label: string;
+  count: number;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: { value: number }[];
+  label?: string;
+}
+
+const COLORS = {
+  light: { accent: "#c17b2f", textSub: "#78716c" },
+  dark: { accent: "#e09a4a", textSub: "#a8a29e" },
+};
+
+function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div
+      className="px-3 py-2 rounded-lg text-xs font-body"
+      style={{
+        background: "var(--bg-sub)",
+        border: "1px solid var(--border)",
+        color: "var(--text-sub)",
+      }}
+    >
+      <p>{label}</p>
+      <p style={{ color: "var(--accent)" }}>{payload[0].value}명</p>
+    </div>
+  );
+}
+
+export default function ViewCounter() {
+  const [data, setData] = useState<ViewsData | null>(null);
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    async function track() {
+      const key = "last_visit_date";
+      const today = new Date().toISOString().slice(0, 10);
+      const last = localStorage.getItem(key);
+
+      if (last !== today) {
+        await fetch("/api/views", { method: "POST" });
+        localStorage.setItem(key, today);
+      }
+
+      const res = await fetch("/api/views");
+      const json: ViewsData = await res.json();
+      setData(json);
+    }
+    track();
+  }, []);
+
+  const colors = resolvedTheme === "dark" ? COLORS.dark : COLORS.light;
+
+  const chartData: ChartEntry[] =
+    data?.chart.map((d) => ({
+      label: d.date.slice(5).replace("-", "/"),
+      count: d.count,
+    })) ?? [];
+
+  if (!data) {
+    return (
+      <p className="text-xs font-body text-(--text-sub) opacity-40">···</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3 w-full max-w-xs">
+      <p className="text-xs font-body text-(--text-sub)">
+        오늘{" "}
+        <span className="text-(--accent) font-semibold">
+          {data.today.toLocaleString()}
+        </span>
+        명 · 전체{" "}
+        <span className="text-(--accent) font-semibold">
+          {data.total.toLocaleString()}
+        </span>
+        명
+      </p>
+
+      <div className="w-full h-20">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            margin={{ top: 4, right: 0, left: 0, bottom: 0 }}
+          >
+            <XAxis
+              dataKey="label"
+              tick={{
+                fontSize: 10,
+                fill: colors.textSub,
+                fontFamily: "inherit",
+              }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <Tooltip
+              content={<CustomTooltip />}
+              cursor={{ fill: "transparent" }}
+            />
+            <Bar dataKey="count" fill={colors.accent} radius={[3, 3, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/ViewCounter.tsx
+++ b/components/ui/ViewCounter.tsx
@@ -30,7 +30,7 @@ function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
   if (!active || !payload?.length) return null;
   return (
     <div
-      className="px-3 py-2 rounded-lg text-xs font-body"
+      className="px-3 py-1 rounded-lg text-xs font-body"
       style={{
         background: "var(--bg-sub)",
         border: "1px solid var(--border)",
@@ -112,6 +112,7 @@ export default function ViewCounter() {
             <Tooltip
               content={<CustomTooltip />}
               cursor={{ fill: "transparent" }}
+              position={{ y: 5.5 }}
             />
             <Bar dataKey="count" fill={colors.accent} radius={[3, 3, 0, 0]} />
           </BarChart>

--- a/docs/visitor-counter.md
+++ b/docs/visitor-counter.md
@@ -1,0 +1,281 @@
+# 방문자 카운터 구현 플랜
+
+## Context
+
+포트폴리오에 Supabase 기반 방문자 카운터를 추가한다.  
+오늘/전체 방문자 수와 최근 5일 바 차트를 Footer 내부에 표시하고,  
+페이지 마운트 시 자동으로 카운트를 증가시킨다.
+
+---
+
+## 사전 작업 (Supabase 대시보드에서 직접 실행)
+
+### 1. 테이블 생성
+
+```sql
+create table daily_views (
+  id bigint generated always as identity primary key,
+  date date unique not null,
+  count int default 0
+);
+```
+
+### 2. RPC 함수 생성 (원자적 upsert용)
+
+```sql
+create or replace function increment_daily_view(p_date date)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  insert into daily_views (date, count)
+  values (p_date, 1)
+  on conflict (date)
+  do update set count = daily_views.count + 1;
+end;
+$$;
+```
+
+### 3. RLS 설정
+
+```sql
+-- RLS 활성화 (클라이언트 직접 접근 차단)
+alter table daily_views enable row level security;
+
+-- anon key로 SELECT만 허용 (Route Handler GET용)
+create policy "anon can read"
+on daily_views for select
+to anon
+using (true);
+
+-- INSERT/UPDATE는 SECURITY DEFINER RPC를 통해서만 가능
+-- (별도 직접 쓰기 정책 없음)
+```
+
+---
+
+## 구현 파일
+
+### 신규 생성
+
+| 파일                            | 역할                                 |
+| ------------------------------- | ------------------------------------ |
+| `.env.local`                    | SUPABASE_URL, SUPABASE_ANON_KEY      |
+| `lib/supabase.ts`               | 서버 전용 Supabase 클라이언트 싱글턴 |
+| `app/api/views/route.ts`        | GET / POST Route Handler             |
+| `components/ui/ViewCounter.tsx` | 카운터 + 바 차트 클라이언트 컴포넌트 |
+
+### 수정
+
+| 파일                           | 변경 내용                    |
+| ------------------------------ | ---------------------------- |
+| `components/layout/Footer.tsx` | ViewCounter 추가 (저작권 위) |
+
+---
+
+## 패키지 설치
+
+```bash
+npm install @supabase/supabase-js recharts
+```
+
+---
+
+## 상세 구현
+
+### `lib/supabase.ts`
+
+```ts
+import { createClient } from "@supabase/supabase-js";
+
+export const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_ANON_KEY!,
+);
+```
+
+- `NEXT_PUBLIC_` 접두사 없이 사용 → 브라우저에 절대 노출되지 않음
+- Route Handler에서만 import
+
+---
+
+### `app/api/views/route.ts`
+
+**GET** — `Promise.all`로 병렬 조회
+
+- `daily_views` 전체 SELECT → `sum(count)` 계산 (total)
+- `date = today` 단건 조회 → today count (`.maybeSingle()`)
+- 최근 5일 SELECT → ascending으로 reverse 후 반환
+
+**POST** — `supabase.rpc('increment_daily_view', { p_date: today })`
+
+- 원자적 upsert, race condition 없음
+- 응답: `{ ok: true }`
+
+반환 타입:
+
+```ts
+interface ViewsResponse {
+  today: number;
+  total: number;
+  chart: { date: string; count: number }[];
+}
+```
+
+---
+
+### `components/ui/ViewCounter.tsx`
+
+`'use client'`
+
+**동작:**
+
+1. `useEffect` 마운트 시 → `POST /api/views` → `GET /api/views` 순차 호출
+2. 로딩 중: `···` 표시 (최소 UI)
+3. 완료 후: 카운터 + 바 차트 렌더
+
+**카운터 텍스트:**
+
+```
+오늘 12명 · 전체 1,024명   (toLocaleString 적용)
+```
+
+**BarChart (recharts):**
+
+- `ResponsiveContainer` + `BarChart` + `Bar` + `XAxis` + `Tooltip`
+- recharts는 CSS 변수를 직접 받지 못하므로 `useTheme`의 `resolvedTheme`으로 다크/라이트 판단 후 hex 값 주입
+  - accent: light `#c17b2f` / dark `#e09a4a`
+  - textSub: light `#78716c` / dark `#a8a29e`
+- X축: `date` → `"MM/DD"` 포맷으로 슬라이싱
+- Bar: `radius={[3, 3, 0, 0]}`, `fill={accent}`
+- Tooltip: 커스텀 컴포넌트로 `var(--bg-sub)`, `var(--border)` 인라인 스타일 적용
+- 차트 높이: `h-20` (80px), 너비: `max-w-xs` (320px) 센터 정렬
+
+**폰트/스타일:** `font-body`, `text-(--text-sub)`, `text-(--accent)`
+
+---
+
+## 환경변수
+
+### `.env.local` (로컬)
+
+```
+SUPABASE_URL=https://xxxxxxxxxxxx.supabase.co
+SUPABASE_ANON_KEY=eyJhbGci...
+```
+
+### Vercel
+
+Vercel 대시보드 → Settings → Environment Variables에 동일하게 추가
+
+---
+
+## 보안 모델
+
+```
+브라우저 → POST /api/views → Route Handler → supabase.rpc() → DB (RLS 우회, SECURITY DEFINER)
+브라우저 → GET  /api/views → Route Handler → supabase.select() → DB (anon SELECT 정책 적용)
+브라우저 → Supabase 직접 호출 불가 (ANON_KEY 미노출)
+```
+
+---
+
+## 검증 방법
+
+1. `npm run dev` 실행 후 페이지 접속
+2. Supabase 대시보드 Table Editor에서 `daily_views` 행이 생성/증가 확인
+3. Footer에 오늘/전체 카운터와 바 차트 정상 렌더링 확인
+4. 다크모드 전환 시 차트 색상 변경 확인
+5. 새로고침마다 today count +1 확인
+
+# supabase에서 DB를 확인했을 때 카운팅은 제대로 이루어지고 있는데 ui에는 적용이 안되고 있음
+
+```md
+현재 상황:
+
+- Supabase daily_views 테이블에 데이터 정상 저장 확인 (2026-04-27, count: 1)
+- UI에서는 오늘 0명 · 전체 0명으로 표시됨
+- DB 연동은 되는데 GET 응답값이 0으로 오는 것으로 추정
+
+app/api/views/route.ts의 GET 핸들러에서
+today count와 total sum(count) 조회 로직을 확인하고 수정해줘.
+```
+
+### 답변 :
+
+```md
+1. 에러 무시 → 에러 로깅 추가  
+   쿼리 실패 시 data는 null이 되고 결과가 0으로 조용히 반환되던 문제를 서버 콘솔에서 확인할 수
+   있게 했습니다.
+
+2. select("count") → select("id, count")  
+   count는 SQL/PostgREST 예약어라 단독으로 select하면 컬럼이 아닌 집계 함수로 해석될 수  
+   있습니다.
+
+---
+
+npm run dev 후 /api/views를 직접 호출하거나 페이지를 열어서, 터미널에 [views GET] 에러가
+찍히는지 확인해주세요.
+
+에러가 찍힌다면 RLS SELECT 정책이 아직 생성되지 않은 것이 원인입니다. Supabase SQL  
+ Editor에서 아래를 실행해주세요.
+
+create policy "anon can read"  
+ on daily_views for select  
+ to anon
+using (true);
+```
+
+| RLS 정책이 아직 없기 때문에 Supabase SQL Editor에서 아래 쿼리 실행
+
+```sql
+create policy "anon can read"
+on daily_views for select
+to anon
+using (true);
+```
+
+는 이미 db 생성하면서 RLS 설정할 때 이미 만들어진 상태
+
+| permission denied for table daily_views
+
+```sql
+grant select on daily_views to anon;
+```
+
+테이블 접근 권한을 추가하여 해결
+
+#### 상황
+
+```md
+anon can read 정책 (RLS) → ✅ 있었음
+grant select to anon → ❌ 없었음 ← 여기서 막힘
+```
+
+### 카운팅 규칙 정하기
+
+현재는 새로고침할 때마다 카운팅이 됨
+
+내가 생각한 문제점 :
+
+의도적으로 무한 새로고침을 실행하면 불필요한 카운팅이 발생할거
+
+- 카운팅 방식 종류
+  - 1. 매 요청마다 카운팅(새로고침 방식)
+       장점 : 구현 단순
+       단점 : 새고로침마다 + 1, 본인 접속도 카운팅
+
+  - 2. localStorage 날짜기록
+       장점 : 하루에 1회 제한
+       단점 : 시크릿 모드, 다른 기기에서 또 카운팅, 브라우저 저장소 지우면 초기화
+
+  - 3. IP 기반
+       장점 : 기기/브라우저 상관없이 중복 방지
+       단점 : vercel Route Handler에서 IP 추출 복잡, 같은 회사 네트워크면 동일 IP로 묶임, 구현 난이도 과함
+
+  - 4. 세션 기반
+       장점 : 탭 단위로 1회만 카운팅
+       단점 : 브라우저 닫으면 초기화
+
+내 자력으로 생각해낸 localstorage 사용

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_ANON_KEY!
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "jiheon-portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.104.1",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
         "next": "16.2.1",
         "next-themes": "^0.4.6",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1289,12 +1291,146 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.1.tgz",
+      "integrity": "sha512-pqFnDKekq1isqlqnzqzyJ3mzmho+o+FjfVTqhKY3PFlwj2anx3OPznO1kbo1ZEwD8zg1r4EAFf/7pplLyX0ocQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.1.tgz",
+      "integrity": "sha512-JjAH4JN9rZzxh4plQnILPrQZXAG6ccoRS6z9hQAGmXpRSwJA+7CWbsDV2R82I8MROlGDsjqj1Ot/cWpTfdf6xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.1.tgz",
+      "integrity": "sha512-RqlLpvgXsjcc27fLyHNGm3zN0KDWXbkdTdaFtaEdX83RsTEqH7BAmshH7zoUMml5lL04naUeRjS3B81O6jZcJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.1.tgz",
+      "integrity": "sha512-dVJHhFB2ErBd0/2qE9G8CedCrGoAtBfL9Q4zbSMXO7b1Cpld916ljSiX21mURUqijPf1WoPQG4Bp/averUzk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.1.tgz",
+      "integrity": "sha512-2bQaLbkRshctkUVuqamwYZDEd+0cGSc9DY9sjh92DcA5hu1F/1AP8p6gxGr76sgdK9Ngi0rh+2Kdh+uC4hcnGA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.1.tgz",
+      "integrity": "sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.104.1",
+        "@supabase/functions-js": "2.104.1",
+        "@supabase/postgrest-js": "2.104.1",
+        "@supabase/realtime-js": "2.104.1",
+        "@supabase/storage-js": "2.104.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1599,6 +1735,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1624,7 +1823,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1634,7 +1832,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1648,6 +1846,21 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2704,6 +2917,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2757,8 +2979,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2838,6 +3181,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3125,6 +3474,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3578,6 +3937,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4052,6 +4417,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4060,6 +4434,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -4102,6 +4486,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5630,8 +6023,75 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5676,6 +6136,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -6266,6 +6732,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6524,7 +6996,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6601,6 +7072,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {
@@ -6716,6 +7218,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.104.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## 개요
Supabase를 연동한 방문자 카운터 기능을 구현했습니다.

## 구현 내용
- Supabase `daily_views` 테이블로 일별 방문자 수 영속 저장
- Next.js Route Handler(`/api/views`)로 GET/POST API 구현
- Footer에 오늘/전체 방문자 수 및 최근 5일 바 차트 표시
- localStorage `last_visit_date`로 하루 1회 중복 카운팅 방지

## 기술적 결정
- JS 변수 누적 방식 제외 → Vercel 서버리스 환경에서 함수 종료 시 휘발
- 배열/큐 방식 제외 → 날짜 정보 부재로 데이터 식별 불가
- total은 별도 컬럼 없이 `sum(count)`로 계산 → 동기화 문제 방지
- `SECURITY DEFINER` RPC 함수로 원자적 upsert → race condition 방지
- `SUPABASE_ANON_KEY` 서버사이드 전용 → 브라우저 미노출

## 스크린샷
<!-- 구현된 UI 캡처 첨부 -->

## 체크리스트
- [x] 로컬 환경에서 카운터 정상 동작 확인
- [x] 새로고침 시 중복 카운팅 방지 확인
- [x] 다크모드 차트 색상 변경 확인
- [x] Vercel 환경변수 설정 필요