### PR TITLE
perf: 프로젝트 카드 hover 시 모달 이미지 preload 적용

### DIFF
--- a/components/ui/ProjectCard.tsx
+++ b/components/ui/ProjectCard.tsx
@@ -6,6 +6,7 @@ import { ExternalLink } from "lucide-react";
 import TechBadge from "./TechBadge";
 import GithubIcon from "@/components/ui/GithubIcon";
 import type { Project } from "@/constants/projects";
+import { PROJECT_DETAILS } from "@/constants/projectDetails";
 
 interface ProjectCardProps {
   project: Project;
@@ -13,8 +14,18 @@ interface ProjectCardProps {
 }
 
 export default function ProjectCard({ project, onClick }: ProjectCardProps) {
+  const handleMouseEnter = () => {
+    // 추가
+    const detail = PROJECT_DETAILS.find((d) => d.slug === project.slug);
+    detail?.images?.forEach((src) => {
+      const img = new window.Image();
+      img.src = src;
+    });
+  };
+
   return (
     <div
+      onMouseEnter={handleMouseEnter}
       onClick={onClick}
       className={`group flex flex-col rounded-2xl border border-(--border) bg-(--bg-sub) overflow-hidden hover:-translate-y-1 transition-transform duration-200 ${onClick ? "cursor-pointer hover:-translate-y-1" : "cursor-default"}`}
     >

--- a/components/ui/SubProjectCard.tsx
+++ b/components/ui/SubProjectCard.tsx
@@ -6,6 +6,7 @@ import { ExternalLink } from "lucide-react";
 import { type Project } from "@/constants/projects";
 import TechBadge from "./TechBadge";
 import GithubIcon from "@/components/ui/GithubIcon";
+import { PROJECT_DETAILS } from "@/constants/projectDetails";
 
 const cardVariants = {
   hidden: { opacity: 0, y: 20 },
@@ -51,6 +52,15 @@ export default function SubProjectCard({
           <motion.div
             key={project.slug}
             variants={cardVariants}
+            onMouseEnter={() => {
+              const detail = PROJECT_DETAILS.find(
+                (d) => d.slug === project.slug,
+              );
+              detail?.images?.forEach((src) => {
+                const img = new window.Image();
+                img.src = src;
+              });
+            }}
             onClick={() => onSelect(project)}
             className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-5 rounded-xl border border-(--border) bg-(--bg-sub) hover:border-(--accent) transition-colors cursor-pointer"
           >


### PR DESCRIPTION
## 개요

프로젝트 카드 hover 시 모달 이미지를 미리 preload하여 모달 열릴 때 이미지 로딩 지연을 개선했습니다.

---

## 문제

모달이 열리는 시점에 처음으로 이미지를 fetch하는 구조라, 첫 로드 시 최대 583ms의 지연이 발생하는 경우가 있었습니다.

---

## 해결 방법

카드에 마우스 hover 시 해당 프로젝트의 이미지를 미리 fetch하도록 구현했습니다.

```tsx
onMouseEnter={() => {
  const detail = PROJECT_DETAILS.find((d) => d.slug === project.slug);
  detail?.images?.forEach((src) => {
    const img = new window.Image();
    img.src = src;
  });
}}
```

---

## 개선 효과

- 페이지 초기 로드에는 영향 없음 (lazy)
- 카드 hover 타이밍에 이미지 fetch → 모달 열릴 때 캐시에서 즉시 표시
- 개선 전: 모달 열릴 때 최대 583ms 지연 발생
- 개선 후: 6~11ms (캐시 히트)(로컬 환경이라서 배포 후 다시 확인할 것)

---

## 변경 파일

- `components/ui/ProjectCard.tsx` — `onMouseEnter` preload 추가
- `components/ui/SubProjectCard.tsx` — `onMouseEnter` preload 추가

---

## 참고

- Lighthouse 측정 범위 밖(사용자 인터랙션 후 동작)이라 Network 탭으로 직접 측정
- 로컬 환경 기준 측정, 실제 효과는 배포 환경에서 확인 필요