### PR TITLE
fix: 방문자 카운터 날짜 계산을 KST 기준으로 통일

### DIFF
--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 
 function getToday(): string {
-  return new Date().toISOString().slice(0, 10);
+  return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
 }
 
 export async function GET() {

--- a/components/ui/ViewCounter.tsx
+++ b/components/ui/ViewCounter.tsx
@@ -50,7 +50,9 @@ export default function ViewCounter() {
   useEffect(() => {
     async function track() {
       const key = "last_visit_date";
-      const today = new Date().toISOString().slice(0, 10);
+      const today = new Date(Date.now() + 9 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10);
       const last = localStorage.getItem(key);
 
       if (last !== today) {


### PR DESCRIPTION
- route.ts getToday(): UTC → KST (UTC+9) 변환 적용
- ViewCounter.tsx localStorage last_visit_date 비교 기준 동일하게 수정